### PR TITLE
I updated the script to so payload options are cleaner and dynamic.

### DIFF
--- a/_msfvenom
+++ b/_msfvenom
@@ -1,5 +1,17 @@
 #compdef msfvenom
 #autoload
+#
+# zsh completion for msfvenom in Metasploit Framework Project (https://www.metasploit.com)
+#
+# github:  https://github.com/Green-m/msfvenom-zsh-completion
+#
+# author:  Green-m (greenm.xxoo@gmail.com)
+#
+# license: GNU General Public License v3.0
+#
+# Copyright (c) 2018, Green-m
+# All rights reserved.
+#
 
 _msfvenom() {
   zmodload zsh/parameter 2>/dev/null

--- a/_msfvenom
+++ b/_msfvenom
@@ -1,17 +1,5 @@
-#compdef msfvenom 
+#compdef msfvenom
 #autoload
-#
-# zsh completion for msfvenom in Metasploit Framework Project (https://www.metasploit.com)
-#
-# github:  https://github.com/Green-m/msfvenom-zsh-completion
-#
-# author:  Green-m (greenm.xxoo@gmail.com)
-#
-# license: GNU General Public License v3.0
-#
-# Copyright (c) 2018, Green-m
-# All rights reserved.
-#
 
 _msfvenom() {
   zmodload zsh/parameter 2>/dev/null
@@ -29,7 +17,7 @@ _msfvenom() {
   local curcontext="$curcontext" state line ret=1
   typeset -A opt_args
 
-  _arguments -C \
+_arguments -C \
     '(-h --help)'{-h,--help}'[show help]' \
     '(-l --list)'{-l,--list}'[list modules]:type:(payloads encoders nops platforms archs encrypt formats all)' \
     '(-p --payload)'{-p,--payload}'[payload to use]:payload:->payloads' \
@@ -38,9 +26,20 @@ _msfvenom() {
     '(-e --encoder)'{-e,--encoder}'[the encoder to use]:encoder:->encoders' \
     '(--smallest)--smallest[generate the smallest possible payload]' \
     '(--encrypt)--encrypt[type of encryption]:encryption:(aes256 base64 rc4 xor)' \
+    '(--encrypt-key)--encrypt-key[key for --encrypt]:key' \
+    '(--encrypt-iv)--encrypt-iv[IV for --encrypt]:iv' \
     '(-a --arch)'{-a,--arch}'[architecture to use]:arch:->archs' \
     '(--platform)--platform[platform for payload]:platform:->platforms' \
     '(-o --out)'{-o,--out}'[save payload to file]:file:_files' \
+    '(-b --bad-chars)'{-b,--bad-chars}'[characters to avoid (e.g. \\x00\\xff)]:badchars' \
+    '(-n --nopsled)'{-n,--nopsled}'[prepend a nopsled of length size]:length' \
+    '(--encoder-space)--encoder-space[max size of encoded payload]:size' \
+    '(-i --iterations)'{-i,--iterations}'[number of times to encode]:count' \
+    '(-c --add-code)'{-c,--add-code}'[include additional win32 shellcode file]:file:_files' \
+    '(-x --template)'{-x,--template}'[custom executable template]:file:_files' \
+    '(-k --keep)'{-k,--keep}'[preserve template behavior and inject as new thread]' \
+    '(-v --var-name)'{-v,--var-name}'[custom variable name for certain formats]:name' \
+    '(-t --timeout)'{-t,--timeout}'[seconds to wait for STDIN (default 30)]:seconds' \
     '*: :->msf_options' && ret=0
 
   case "$state" in

--- a/_msfvenom
+++ b/_msfvenom
@@ -23,6 +23,7 @@ _msfvenom() {
   local FORMAT_CACHE="$CACHE_DIR/formats"
   local ENCODER_CACHE="$CACHE_DIR/encoders"
   local PLATFORM_CACHE="$CACHE_DIR/platforms"
+  local NOPS_CACHE="$CACHE_DIR/nops"
 
   [[ ! -d "$OPT_CACHE_DIR" ]] && mkdir -p "$OPT_CACHE_DIR"
 
@@ -44,7 +45,7 @@ _arguments -C \
     '(--platform)--platform[platform for payload]:platform:->platforms' \
     '(-o --out)'{-o,--out}'[save payload to file]:file:_files' \
     '(-b --bad-chars)'{-b,--bad-chars}'[characters to avoid (e.g. \\x00\\xff)]:badchars' \
-    '(-n --nopsled)'{-n,--nopsled}'[prepend a nopsled of length size]:length' \
+    '(-n --nops --nopsled)'{-n,--nops,--nopsled}'[nopsled length and optional generator]:length: :nop:->nops' \
     '(--encoder-space)--encoder-space[max size of encoded payload]:size' \
     '(-i --iterations)'{-i,--iterations}'[number of times to encode]:count' \
     '(-c --add-code)'{-c,--add-code}'[include additional win32 shellcode file]:file:_files' \
@@ -59,6 +60,11 @@ _arguments -C \
       local -a p_list
       p_list=(${(f)"$(cat_or_build "$PAYLOAD_CACHE" "payloads")"})
       [[ ${#p_list} -gt 0 ]] && _describe 'payloads' p_list && ret=0
+      ;;
+    nops)
+      local -a n_list
+      n_list=(${(f)"$(cat_or_build "$NOPS_CACHE" "nops")"})
+      [[ ${#n_list} -gt 0 ]] && _values 'nops' "${(@)n_list}" && ret=0
       ;;
     archs)
       local -a a_list

--- a/_msfvenom
+++ b/_msfvenom
@@ -1,5 +1,17 @@
-#compdef msfvenom
+#compdef msfvenom 
 #autoload
+#
+# zsh completion for msfvenom in Metasploit Framework Project (https://www.metasploit.com)
+#
+# github:  https://github.com/Green-m/msfvenom-zsh-completion
+#
+# author:  Green-m (greenm.xxoo@gmail.com)
+#
+# license: GNU General Public License v3.0
+#
+# Copyright (c) 2018, Green-m
+# All rights reserved.
+#
 
 _msfvenom() {
   zmodload zsh/parameter 2>/dev/null

--- a/_msfvenom
+++ b/_msfvenom
@@ -1,387 +1,111 @@
-#compdef msfvenom 
+#compdef msfvenom
 #autoload
-#
-# zsh completion for msfvenom in Metasploit Framework Project (https://www.metasploit.com)
-#
-# github:  https://github.com/Green-m/msfvenom-zsh-completion
-#
-# author:  Green-m (greenm.xxoo@gmail.com)
-#
-# license: GNU General Public License v3.0
-#
-# Copyright (c) 2018, Green-m
-# All rights reserved.
-#
-
-VENOM_CACHE_FILE=~/.zsh/venom-cache
-
-venom-clear-cache() {
-  rm $VENOM_CACHE_FILE
-}
-
-venom-cache-payloads() {
-
-	if   [ -x "$(command -v msfvenom)" ]
-	then 
-			VENOM="msfvenom"
-	elif [ -n "$_comp_command1" ]
-	then
-			VENOM=$_comp_command1
-	else
-			echo "Cound not find msfvenom path in system env, please run msfvenom with path."
-	fi
-
-	if [[ ! -d ${VENOM_CACHE_FILE:h} ]]; then
-      mkdir -p ${VENOM_CACHE_FILE:h}
-  fi
-
-  if [[ ! -f $VENOM_CACHE_FILE ]]; then
-      echo -n "(...caching Metasploit Payloads...)"
-      $VENOM --list payload|grep -e "^.*/" | awk '{print $1}' >> $VENOM_CACHE_FILE
-  fi
-}
-
 
 _msfvenom() {
+  zmodload zsh/parameter 2>/dev/null
+  
+  local CACHE_DIR="$HOME/.zsh/venom-cache"
+  local OPT_CACHE_DIR="$CACHE_DIR/options"
+  local PAYLOAD_CACHE="$CACHE_DIR/payloads"
+  local ARCH_CACHE="$CACHE_DIR/archs"
+  local FORMAT_CACHE="$CACHE_DIR/formats"
+  local ENCODER_CACHE="$CACHE_DIR/encoders"
+  local PLATFORM_CACHE="$CACHE_DIR/platforms"
 
-  local curcontext="$curcontext" state line
+  [[ ! -d "$OPT_CACHE_DIR" ]] && mkdir -p "$OPT_CACHE_DIR"
+
+  local curcontext="$curcontext" state line ret=1
   typeset -A opt_args
 
-	_arguments  -C \
-  '(-h --help)'{-h,--help}'[show help]' \
-  '(-l --list)'{-l,--list}'[List all modules for type. Types are: payloads, encoders, nops, platforms, archs, encrypt, formats, all]' \
-  '(-p --payload)'{-p,--payload}'[Payload to use (--list payloads to list, --list-options for arguments). Specify - or STDIN for custom]' \
-  '(--list-options)--list-options[List --payload <value> standard, advanced and evasion options]' \
-  '(-f --format)'{-f,--format}'[Output format (use --list formats to list)]' \
-  '(-e --encoder)'{-e,--encoder}'[The encoder to use (use --list encoders to list)]' \
-  '(--smallest)--smallest[Generate the smallest possible payload using all available encoders]' \
-  '(--encrypt)--encrypt[The type of encryption or encoding to apply to the shellcode (use --list encrypt to list)]' \
-  '(--encrypt-key)--encrypt-key[A key to be used for --encrypt]' \
-  '(--encrypt-iv)--encrypt-iv[An initialization vector for --encrypt]' \
-  '(-a --arch)'{-a,--arch}'[the architecture to use for --payload and --encoders (use --list archs to list)]' \
-  '(--platform)--platform[The platform for --payload (use --list platforms to list)]' \
-  '(-o --out)'{-o,--out}'[Save the payload to a file]' \
-  '(-b --bad-chars)'{-b,--bad-chars}'[Characters to avoid example: "\x00\xff"]' \
-  '(-n --nopsled)'{-n,--nopsled}'[Prepend a nopsled of \[length\] size on to the payload]' \
-  '(--encoder-space)--encoder-space[The maximum size of the encoded payload (defaults to the -s value)]' \
-  '(-i --iterations)'{-i,--iterations}'[The number of times to encode the payload]' \
-  '(-c --add-code)'{-c,--add-code}'[Specify an additional win32 shellcode file to include]' \
-  '(-x --template)'{-x,--template}'[Specify a custom executable file to use as a template]' \
-  '(-k --keep)'{-k,--keep}'[Preserve the --template behaviour and inject the payload as a new thread]' \
-  '(-v --var-name)'{-v,--var-name}'[Specify a custom variable name to use for certain output formats]' \
-  '(-t --timeout)'{-t,--timeout}'[The number of seconds to wait when reading the payload from STDIN (default 30, 0 to disable)]' \
-  '*: :($(__msfvenom_options))' && ret=0
+  _arguments -C \
+    '(-h --help)'{-h,--help}'[show help]' \
+    '(-l --list)'{-l,--list}'[list modules]:type:(payloads encoders nops platforms archs encrypt formats all)' \
+    '(-p --payload)'{-p,--payload}'[payload to use]:payload:->payloads' \
+    '(--list-options)--list-options[list payload options]' \
+    '(-f --format)'{-f,--format}'[output format]:format:->formats' \
+    '(-e --encoder)'{-e,--encoder}'[the encoder to use]:encoder:->encoders' \
+    '(--smallest)--smallest[generate the smallest possible payload]' \
+    '(--encrypt)--encrypt[type of encryption]:encryption:(aes256 base64 rc4 xor)' \
+    '(-a --arch)'{-a,--arch}'[architecture to use]:arch:->archs' \
+    '(--platform)--platform[platform for payload]:platform:->platforms' \
+    '(-o --out)'{-o,--out}'[save payload to file]:file:_files' \
+    '*: :->msf_options' && ret=0
 
+  case "$state" in
+    payloads)
+      local -a p_list
+      p_list=(${(f)"$(cat_or_build "$PAYLOAD_CACHE" "payloads")"})
+      [[ ${#p_list} -gt 0 ]] && _describe 'payloads' p_list && ret=0
+      ;;
+    archs)
+      local -a a_list
+      a_list=(${(f)"$(cat_or_build "$ARCH_CACHE" "archs")"})
+      [[ ${#a_list} -gt 0 ]] && _values 'architectures' "${(@)a_list}" && ret=0
+      ;;
+    encoders)
+      local -a e_list
+      e_list=(${(f)"$(cat_or_build "$ENCODER_CACHE" "encoders")"})
+      [[ ${#e_list} -gt 0 ]] && _values 'encoders' "${(@)e_list}" && ret=0
+      ;;
+    formats)
+      local -a f_list
+      f_list=(${(f)"$(cat_or_build "$FORMAT_CACHE" "formats")"})
+      [[ ${#f_list} -gt 0 ]] && _values 'formats' "${(@)f_list}" && ret=0
+      ;;
+    platforms)
+      local -a plat_list
+      plat_list=(${(f)"$(cat_or_build "$PLATFORM_CACHE" "platforms")"})
+      [[ ${#plat_list} -gt 0 ]] && _values 'platforms' "${(@)plat_list}" && ret=0
+      ;;
+    msf_options)
+      if [[ ! "$words[$CURRENT]" == -* ]]; then
+        local selected_payload=""
+        local i
+        for (( i=1; i < $#words; i++ )); do
+          if [[ "$words[$i]" == "-p" || "$words[$i]" == "--payload" ]]; then
+            selected_payload="${words[$i+1]}"
+            break
+          fi
+        done
 
-	lastword=${words[${#words[@]}-1]}
-
-	case "$lastword" in
-		(-p|--payload)
-		  _values 'payload' $(__msfvenom_payloads)
-	  ;;
-
-	  (-l|--list)
-			local lists=('payloads' 'encoders' 'nops' 'platforms' 'archs' 'encrypt' 'formats' 'all')
-			_values 'list' $lists
-		;;
-
-		(-encrypt)
-			local encrypts=('aes256' 'base64' 'rc4' 'xor')
-			_values 'encrypt' $encrypts
-		;;
-
-		(-a|--arch)
-			_values 'arch' $(__msfvenom_archs)
-		;;
-
-		(-platform)
-			_values 'platform' $(__msfvenom_platforms)
-		;;
-
-		(-f|--format)
-			_values 'format' $(__msfvenom_formats)
-		;;
-
-		(-e|--encoder)
-			_values 'encoder' $(__msfvenom_encoders)
-		;;
-
-		(-o|--out|-x|--template|-c|--add-code)
-			_files
-		;;
-
-		(*)
-
-		;;
-
-	esac
+        if [[ -n "$selected_payload" ]]; then
+          local -a dynamic_opts
+          dynamic_opts=(${(f)"$(__msfvenom_dynamic_opts "$selected_payload" "$OPT_CACHE_DIR")"})
+          [[ ${#dynamic_opts} -gt 0 ]] && _values "options for $selected_payload" "${(@)dynamic_opts}" && ret=0
+        else
+          _values 'general options' 'LHOST=' 'LPORT=' 'RHOST=' 'RPORT=' && ret=0
+        fi
+      fi
+      ;;
+  esac
+  return ret
 }
 
-
-__msfvenom_payloads(){
-	local msf_payloads
-
-	# we cache the list of packages (originally from the macports plugin)
-  venom-cache-payloads
-  msf_payloads=`cat $VENOM_CACHE_FILE`
-
-  for line in $msf_payloads; do
-    echo "$line"
-	done
+cat_or_build() {
+  local cache_file=$1
+  local type=$2
+  if [[ ! -f "$cache_file" ]]; then
+    mkdir -p "${cache_file:h}"
+    msfvenom --list "$type" 2>/dev/null | \
+      awk '/^[[:space:]]{4}[a-z0-9]/ {print $1}' | \
+      grep -vE '^(Name|----|Framework|^$)' > "$cache_file"
+  fi
+  cat "$cache_file"
 }
 
-__msfvenom_archs(){
-	local archs
-	archs=(
-		'aarch64'
-    'armbe'
-    'armle'
-    'cbea'
-    'cbea64'
-    'cmd'
-    'dalvik'
-    'firefox'
-    'java'
-    'mips'
-    'mips64'
-    'mips64le'
-    'mipsbe'
-    'mipsle'
-    'nodejs'
-    'php'
-    'ppc'
-    'ppc64'
-    'ppc64le'
-    'ppce500v2'
-    'python'
-    'r'
-    'ruby'
-    'sparc'
-    'sparc64'
-    'tty'
-    'x64'
-    'x86'
-    'x86_64'
-    'zarch'
-	)
+__msfvenom_dynamic_opts() {
+  local payload=$1
+  local cache_dir=$2
+  local cache_name="${payload//\//_}" 
+  local cache_path="$cache_dir/$cache_name"
 
-	for line in $archs; do
-    echo "$line"
-	done
-
+  if [[ ! -f "$cache_path" ]]; then
+    msfvenom -p "$payload" --list-options 2>/dev/null | \
+      awk '$0 ~ /yes/ || $0 ~ /no/ {print $1}' | \
+      grep -vE '^(Name|----|^$|Current|Required|Description)' | \
+      sort -u | sed 's/$/=/' > "$cache_path"
+  fi
+  cat "$cache_path"
 }
 
-__msfvenom_encoders(){
-	local encoders
-	encoders=(
-		'cmd/brace'
-		'cmd/echo'
-		'cmd/generic_sh'
-		'cmd/ifs'
-		'cmd/perl'
-		'cmd/powershell_base64'
-		'cmd/printf_php_mq'
-		'generic/eicar'
-		'generic/none'
-		'mipsbe/byte_xori'
-		'mipsbe/longxor'
-		'mipsle/byte_xori'
-		'mipsle/longxor'
-		'php/base64'
-		'ppc/longxor'
-		'ppc/longxor_tag'
-		'ruby/base64'
-		'sparc/longxor_tag'
-		'x64/xor'
-		'x64/xor_dynamic'
-		'x64/zutto_dekiru'
-		'x86/add_sub'
-		'x86/alpha_mixed'
-		'x86/alpha_upper'
-		'x86/avoid_underscore_tolower'
-		'x86/avoid_utf8_tolower'
-		'x86/bloxor'
-		'x86/bmp_polyglot'
-		'x86/call4_dword_xor'
-		'x86/context_cpuid'
-		'x86/context_stat'
-		'x86/context_time'
-		'x86/countdown'
-		'x86/fnstenv_mov'
-		'x86/jmp_call_additive'
-		'x86/nonalpha'
-		'x86/nonupper'
-		'x86/opt_sub'
-		'x86/service'
-		'x86/shikata_ga_nai'
-		'x86/single_static_bit'
-		'x86/unicode_mixed'
-		'x86/unicode_upper'
-		'x86/xor_dynamic'
-	)
-
-	for line in $encoders; do
-    echo "$line"
-	done
-}
-
-__msfvenom_platforms(){
-	local platforms
-	platforms=(
-		'aix'
-    'android'
-    'apple_ios'
-    'bsd'
-    'bsdi'
-    'cisco'
-    'firefox'
-    'freebsd'
-    'hardware'
-    'hpux'
-    'irix'
-    'java'
-    'javascript'
-    'juniper'
-    'linux'
-    'mainframe'
-    'multi'
-    'netbsd'
-    'netware'
-    'nodejs'
-    'openbsd'
-    'osx'
-    'php'
-    'python'
-    'r'
-    'ruby'
-    'solaris'
-    'unix'
-    'unknown'
-    'windows'
-	)
-
-	for line in $platforms; do
-    echo "$line"
-	done
-}
-
-__msfvenom_formats(){
-	local formats
-	formats=(
-		'asp'
-    'aspx'
-    'aspx-exe'
-    'axis2'
-    'dll'
-    'elf'
-    'elf-so'
-    'exe'
-    'exe-only'
-    'exe-service'
-    'exe-small'
-    'hta-psh'
-    'jar'
-    'jsp'
-    'loop-vbs'
-    'macho'
-    'msi'
-    'msi-nouac'
-    'osx-app'
-    'psh'
-    'psh-cmd'
-    'psh-net'
-    'psh-reflection'
-    'vba'
-    'vba-exe'
-    'vba-psh'
-    'vbs'
-    'war'
-		'bash'
-    'c'
-    'csharp'
-    'dw'
-    'dword'
-    'hex'
-    'java'
-    'js_be'
-    'js_le'
-    'num'
-    'perl'
-    'pl'
-    'powershell'
-    'ps1'
-    'py'
-    'python'
-    'raw'
-    'rb'
-    'ruby'
-    'sh'
-    'vbapplication'
-    'vbscript'
-	)
-
-	for line in $formats; do
-    echo "$line"
-	done
-}
-
-# For most common options, not accurately
-__msfvenom_options(){
-	local options 
-	options=(
- 		LHOST= \
-		LPORT= \
-		EXITFUNC= \
-		RHOST= \
-		StageEncoder= \
-		AutoLoadStdapi= \
-		AutoRunScript= \
-		AutoSystemInfo= \
-		AutoVerifySession= \
-		AutoVerifySessionTimeout= \
-		EnableStageEncoding= \
-		EnableUnicodeEncoding= \
-		HandlerSSLCert= \
-		InitialAutoRunScript= \
-		PayloadBindPort= \
-		PayloadProcessCommandLine= \
-		PayloadUUIDName= \
-		PayloadUUIDRaw= \
-		PayloadUUIDSeed= \
-		PayloadUUIDTracking= \
-		PrependMigrate= \
-		PrependMigrateProc= \
-		ReverseAllowProxy= \
-		ReverseListenerBindAddress= \
-		ReverseListenerBindPort= \
-		ReverseListenerComm= \
-		ReverseListenerThreaded= \
-		SessionCommunicationTimeout= \
-		SessionExpirationTimeout= \
-		SessionRetryTotal= \
-		SessionRetryWait= \
-		StageEncoder= \
-		StageEncoderSaveRegisters= \
-		StageEncodingFallback= \
-		StagerRetryCount= \
-		StagerRetryWait= \
-		VERBOSE= \
-		WORKSPACE=
-	)
-
- echo $options
-}
-
-
-#_msfvenom "$@"
-
-
-
-
-
-
-
-
-
-
-
+_msfvenom "$@"

--- a/msfvenom.plugin.zsh
+++ b/msfvenom.plugin.zsh
@@ -1,0 +1,17 @@
+msfvenom-recache() {
+  local cache_dir="$HOME/.zsh/venom-cache"
+  local types=(payloads archs formats encoders platforms)
+  
+  echo "[!] Clearing msfvenom completion cache..."
+  rm -rf "$cache_dir"
+  mkdir -p "$cache_dir/options"
+
+  for t in $types; do
+    echo -n "[#] Indexing $t... "
+    msfvenom --list "$t" 2>/dev/null | \
+      awk '/^[[:space:]]{4}[a-z0-9]/ {print $1}' | \
+      grep -vE '^(Name|----|Framework|^$)' > "$cache_dir/$t"
+    echo "Done."
+  done
+  echo "Cache fully rebuilt."
+}

--- a/msfvenom.plugin.zsh
+++ b/msfvenom.plugin.zsh
@@ -1,6 +1,6 @@
 msfvenom-recache() {
   local cache_dir="$HOME/.zsh/venom-cache"
-  local types=(payloads archs formats encoders platforms)
+  local types=(payloads archs formats encoders platforms nops)
   
   echo "[!] Clearing msfvenom completion cache..."
   rm -rf "$cache_dir"


### PR DESCRIPTION
Completion now shows options specific for the payload you are using (so exec will show CMD=) instead of generic LHOST=

Fixed it so the generic options don't appear in everything and clutter the menus

updated the caching system in the ~/.zsh/venom-cache folder. it is dynamically filled by either tabbing a flag or be running msfvenom-recache

added msfvenom-recache that clears up outdated msfvenom modules in case of errors or updates

Cheers, Jett